### PR TITLE
<feature> Add support of choosing storage class

### DIFF
--- a/source/src/migration_lib/client.py
+++ b/source/src/migration_lib/client.py
@@ -213,7 +213,7 @@ class S3DownloadClient(DownloadClient):
     def _list_objects_versions(self, latest_changes_only=False):
         """List objects from S3 bucket"""
         logger.info(
-            'S3> List objects in bucket {self._bucket_name} with version info')
+            f'S3> List objects in bucket {self._bucket_name} with version info')
 
         # TODO implement latest_changes_only.
         job_list = []
@@ -318,7 +318,7 @@ class AliOSSDownloadClient(DownloadClient):
 
     def _list_objects_without_version(self, latest_changes_only=False):
         logger.info(
-            'OSS> list objects from OSS in bucket {self._bucket_name} without version info')
+            f'OSS> list objects from OSS in bucket {self._bucket_name} without version info')
         # TODO implement latest_changes_only.
         job_list = []
 
@@ -343,7 +343,7 @@ class AliOSSDownloadClient(DownloadClient):
 
     def _list_objects_versions(self, latest_changes_only=False):
         logger.info(
-            'OSS> List objects in bucket {self._bucket_name} with version info')
+            f'OSS> List objects in bucket {self._bucket_name} with version info')
         # TODO implement latest_changes_only.
         job_list = []
 


### PR DESCRIPTION
*Issue #, if available:*
Issue #4 

*Description of changes:*
Add an extra parameter destStorageClass and use that while uploading to destination S3.

allowedValues: ['STANDARD', 'STANDARD_IA', 'ONEZONE_IA', 'INTELLIGENT_TIERING']

'GLACIER' and 'DEEP_ARCHIVE' are currently not included. Will add those two if we have customer request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
