### PR TITLE
fix: The EC2 version's Dashboard will not show old metrics

### DIFF
--- a/source/lib/dashboard-stack.ts
+++ b/source/lib/dashboard-stack.ts
@@ -6,12 +6,6 @@ import * as sqs from '@aws-cdk/aws-sqs';
 
 import { RunType } from './main-stack';
 
-// Dashboard Name Space
-export const enum DBNamespace {
-    NS_EC2 = "DRH/EC2",
-    NS_LAMBDA = "DRH/Lambda"
-}
-
 export interface DBProps {
     readonly runType: RunType,
     readonly queue: sqs.Queue
@@ -27,10 +21,8 @@ export class DashboardStack extends Construct {
     constructor(scope: Construct, id: string, props: DBProps) {
         super(scope, id);
 
-        const cwNamespace = props.runType === RunType.EC2 ? DBNamespace.NS_EC2 : DBNamespace.NS_LAMBDA
-
         const completedBytes = new cw.Metric({
-            namespace: cwNamespace,
+            namespace: `${Aws.STACK_NAME}`,
             metricName: 'CompletedBytes',
             statistic: 'Sum',
             period: Duration.minutes(1),
@@ -38,7 +30,7 @@ export class DashboardStack extends Construct {
         })
 
         const transferredObjects = new cw.Metric({
-            namespace: cwNamespace,
+            namespace: `${Aws.STACK_NAME}`,
             metricName: 'TransferredObjects',
             statistic: 'Sum',
             period: Duration.minutes(1),
@@ -46,7 +38,7 @@ export class DashboardStack extends Construct {
         })
 
         const failedObjects = new cw.Metric({
-            namespace: cwNamespace,
+            namespace: `${Aws.STACK_NAME}`,
             metricName: 'FailedObjects',
             statistic: 'Sum',
             period: Duration.minutes(1),
@@ -54,7 +46,7 @@ export class DashboardStack extends Construct {
         })
 
         const lambdaMemory = new cw.Metric({
-            namespace: cwNamespace,
+            namespace: `${Aws.STACK_NAME}`,
             metricName: 'MaxMemoryUsed',
             statistic: 'Max',
             period: Duration.minutes(1),

--- a/source/lib/ec2-worker-stack.ts
+++ b/source/lib/ec2-worker-stack.ts
@@ -7,7 +7,6 @@ import * as sqs from '@aws-cdk/aws-sqs';
 import * as cw from '@aws-cdk/aws-cloudwatch';
 
 import { RetentionDays, LogGroup, FilterPattern } from '@aws-cdk/aws-logs';
-import { DBNamespace } from './dashboard-stack';
 
 export interface Env {
     [key: string]: any;
@@ -160,25 +159,23 @@ export class Ec2WorkerStack extends Construct {
 
         this.workerAsg.addToRolePolicy(cwAgentPolicy)
 
-        const namespace = DBNamespace.NS_EC2
-
         ec2LG.addMetricFilter('CompletedBytes', {
             metricName: 'CompletedBytes',
-            metricNamespace: namespace,
+            metricNamespace: `${Aws.STACK_NAME}`,
             metricValue: '$Bytes',
             filterPattern: FilterPattern.literal('[data, time, p="----->Completed", Bytes, ...]')
         })
 
         ec2LG.addMetricFilter('Transferred-Objects', {
             metricName: 'TransferredObjects',
-            metricNamespace: namespace,
+            metricNamespace: `${Aws.STACK_NAME}`,
             metricValue: '1',
             filterPattern: FilterPattern.literal('[data, time, p="----->Transferred", ..., s="DONE"]')
         })
 
         ec2LG.addMetricFilter('Failed-Objects', {
             metricName: 'FailedObjects',
-            metricNamespace: namespace,
+            metricNamespace: `${Aws.STACK_NAME}`,
             metricValue: '1',
             filterPattern: FilterPattern.literal('[data, time, p="----->Transferred", ..., s="ERROR"]')
         })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using namespace to solve this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
