### PR TITLE
Add proxy capabilities for ec2 instances

### DIFF
--- a/source/bin/main-stack.ts
+++ b/source/bin/main-stack.ts
@@ -28,6 +28,7 @@ import {
 } from "cdk-nag";
 
 const app = new App();
+const stackName = process.env.CUSTOM_STACK_NAME || 'DataTransferS3Stack';
 
 function stackSuppressions(
     stacks: Stack[],
@@ -39,7 +40,7 @@ function stackSuppressions(
 }
 
 stackSuppressions([
-    new DataTransferS3Stack(app, 'DataTransferS3Stack'),
+    new DataTransferS3Stack(app, stackName),
 ], [
     { id: 'AwsSolutions-IAM5', reason: 'some policies need to get dynamic resources' },
     { id: 'AwsSolutions-IAM4', reason: 'these policies is used by CDK Customer Resource lambda' },

--- a/source/lib/ec2-finder-stack.ts
+++ b/source/lib/ec2-finder-stack.ts
@@ -257,6 +257,10 @@ export class Ec2FinderStack extends Construct {
             `echo "export INCLUDE_METADATA=${props.env.INCLUDE_METADATA}" >> env.sh`,
             `echo "export AWS_DEFAULT_REGION=${Aws.REGION}" >> env.sh`,
 
+            `echo "export HTTP_PROXY=${props.env.PROXY_HOST}" >> env.sh`,
+            `echo "export HTTPS_PROXY=${props.env.PROXY_HOST}" >> env.sh`,
+            `echo "export NO_PROXY=169.254.169.254" >> env.sh`,
+
             // Create the script
             'echo "source /home/ec2-user/env.sh" >> start-finder.sh',
             'echo "nohup ./dthcli run -t Finder |& tee -a /home/ec2-user/finder.log" >> start-finder.sh',

--- a/source/lib/ec2-worker-stack.ts
+++ b/source/lib/ec2-worker-stack.ts
@@ -237,6 +237,10 @@ export class Ec2WorkerStack extends Construct {
             `echo "export INCLUDE_METADATA=${props.env.INCLUDE_METADATA}" >> env.sh`,
             `echo "export AWS_DEFAULT_REGION=${Aws.REGION}" >> env.sh`,
 
+            `echo "export HTTP_PROXY=${props.env.PROXY_HOST}" >> env.sh`,
+            `echo "export HTTPS_PROXY=${props.env.PROXY_HOST}" >> env.sh`,
+            `echo "export NO_PROXY=169.254.169.254" >> env.sh`,
+
             // Create the script
             'echo "source /home/ec2-user/env.sh" >> start-worker.sh',
             'echo "nohup ./dthcli run -t Worker |& tee -a /home/ec2-user/worker.log" >> start-worker.sh',

--- a/source/lib/main-stack.ts
+++ b/source/lib/main-stack.ts
@@ -195,6 +195,13 @@ export class DataTransferS3Stack extends Stack {
     })
     this.addToParamLabels('Destination Credentials', destCredentials.logicalId)
 
+    const proxyHost = new CfnParameter(this, 'proxyHost', {
+      description: 'Proxy server to be used by EC2 tasks. Leave blank if not needed.',
+      default: '',
+      type: 'String'
+    })
+    this.addToParamLabels('Proxy Host', proxyHost.logicalId)
+
 
     // 'STANDARD'|'REDUCED_REDUNDANCY'|'STANDARD_IA'|'ONEZONE_IA'|'INTELLIGENT_TIERING'|'GLACIER'|'DEEP_ARCHIVE'|'OUTPOSTS',
     const destStorageClass = new CfnParameter(this, 'destStorageClass', {
@@ -293,6 +300,7 @@ export class DataTransferS3Stack extends Stack {
     this.addToParamGroups('Destination Information', destBucket.logicalId, destPrefix.logicalId, destRegion.logicalId, destInCurrentAccount.logicalId, destCredentials.logicalId, destStorageClass.logicalId, destAcl.logicalId)
     this.addToParamGroups('Notification Information', alarmEmail.logicalId)
     this.addToParamGroups('EC2 Cluster Information', ec2VpcId.logicalId, ec2Subnets.logicalId, finderEc2Memory.logicalId, ec2CronExpression.logicalId)
+    this.addToParamGroups('Network Settings', proxyHost.logicalId)
 
     // let lambdaMemory: CfnParameter | undefined
     let maxCapacity: CfnParameter | undefined
@@ -413,6 +421,7 @@ export class DataTransferS3Stack extends Stack {
       FINDER_DEPTH: finderDepth.valueAsString,
       FINDER_NUMBER: finderNumber.valueAsString,
 
+      PROXY_HOST: proxyHost.valueAsString,
     }
 
     const finderProps: Ec2FinderProps = {
@@ -455,6 +464,7 @@ export class DataTransferS3Stack extends Stack {
       WORKER_NUMBER: workerNumber.valueAsString,
       INCLUDE_METADATA: includeMetadata.valueAsString,
 
+      PROXY_HOST: proxyHost.valueAsString,
     }
 
     let asgName = undefined


### PR DESCRIPTION
*Description of changes:*

This PR adds capabilities to set custom proxy configuration on ec2 instances that allows downloading necessary packages and sending artifacts to target s3 buckets in situation when direct internet access via Internet Gateway or NAT Gateway is not available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
